### PR TITLE
Fix auth loading timeout when backend is down

### DIFF
--- a/frontend/__tests__/useAuth.test.ts
+++ b/frontend/__tests__/useAuth.test.ts
@@ -44,7 +44,10 @@ describe("useAuth", () => {
     });
 
     expect(res).toEqual({ success: true, data: { token: "abc", user: { email: "a@b.com" } } });
-    expect((globalThis as any).fetch).toHaveBeenCalledWith(expect.stringContaining("/auth/login"), expect.objectContaining({ method: "POST" }));
+    expect((globalThis as any).fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/auth/login"),
+      expect.objectContaining({ method: "POST" })
+    );
   });
 
   test("login failure returns backend error", async () => {
@@ -135,7 +138,10 @@ describe("useAuth", () => {
     });
 
     expect(res).toEqual({ success: true, data: { id: "1", name: "Test", email: "t@e.com", token: "tok" } });
-    expect((globalThis as any).fetch).toHaveBeenCalledWith(expect.stringContaining("/auth/signup"), expect.objectContaining({ method: "POST" }));
+    expect((globalThis as any).fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/auth/signup"),
+      expect.objectContaining({ method: "POST" })
+    );
   });
 
   test("register failure surfaces backend error", async () => {
@@ -230,6 +236,7 @@ describe("useAuth", () => {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email: "test@example.com", password: "password123" }),
+        signal: expect.any(Object),
       })
     );
   });
@@ -252,6 +259,7 @@ describe("useAuth", () => {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ name: "John Doe", email: "john@example.com", password: "password123" }),
+        signal: expect.any(Object),
       })
     );
   });

--- a/frontend/hooks/useAuth.ts
+++ b/frontend/hooks/useAuth.ts
@@ -8,43 +8,54 @@ type AuthResult = { success: true; data?: any } | { success: false; error: strin
 
 import { API_URL } from "./api";
 const API_BASE = process.env.REACT_APP_API_BASE || API_URL;
+const REQUEST_TIMEOUT_MS = 8000;
 
 export function useAuth() {
   const [loading, setLoading] = useState(false);
 
   async function login(email: string, password: string): Promise<AuthResult> {
     setLoading(true);
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
     try {
       const res = await fetch(`${API_BASE}/auth/login`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email, password }),
+        signal: controller.signal,
       });
       const json = await res.json();
-      setLoading(false);
       if (res.ok) return { success: true, data: json };
       return { success: false, error: json?.error || json?.message || "Invalid credentials." };
     } catch (err: any) {
+      const isTimeout = err?.name === "AbortError";
+      return { success: false, error: isTimeout ? "Network error." : (err?.message || "Network error.") };
+    } finally {
+      clearTimeout(timeoutId);
       setLoading(false);
-      return { success: false, error: err?.message || "Network error." };
     }
   }
 
   async function register(fullName: string, email: string, password: string): Promise<AuthResult> {
     setLoading(true);
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
     try {
       const res = await fetch(`${API_BASE}/auth/signup`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ name: fullName, email, password }),
+        signal: controller.signal,
       });
       const json = await res.json();
-      setLoading(false);
       if (res.ok) return { success: true, data: json };
       return { success: false, error: json?.error || json?.message || "Registration failed." };
     } catch (err: any) {
+      const isTimeout = err?.name === "AbortError";
+      return { success: false, error: isTimeout ? "Network error." : (err?.message || "Network error.") };
+    } finally {
+      clearTimeout(timeoutId);
       setLoading(false);
-      return { success: false, error: err?.message || "Network error." };
     }
   }
 


### PR DESCRIPTION
## Summary
Fixes an issue where the Login and Register buttons would stay in a loading state indefinitely when the backend API server is down.

## Changes
- Added a request timeout to auth API calls (login/register)
- Ensured loading state is always cleared after a request completes or fails
- Updated auth hook tests to account for the timeout behavior

## Behavior Before
- When the backend was not running, submitting Login or Register caused the button to load forever.

## Behavior After
- When the backend is unreachable, the request times out after a few seconds and a network error is shown.
- The loading indicator stops and the user can retry.

Closes #86
