### PR TITLE
Fix auth loading timeout (#86)

### DIFF
--- a/frontend/hooks/useAuth.ts
+++ b/frontend/hooks/useAuth.ts
@@ -11,6 +11,7 @@ type AuthResult =
 
 import { API_URL } from "./api";
 const API_BASE = process.env.REACT_APP_API_BASE || API_URL;
+const REQUEST_TIMEOUT_MS = 6000;
 
 export function useAuth() {
   const [loading, setLoading] = useState(false);
@@ -36,15 +37,17 @@ export function useAuth() {
     defaultError: string,
   ): Promise<AuthResult> {
     setLoading(true);
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
     try {
       const res = await fetch(`${API_BASE}${endpoint}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
+        signal: controller.signal,
       });
 
       const json = await res.json();
-      setLoading(false);
 
       if (res.ok && json?.token) {
         await AsyncStorage.setItem("accessToken", json.token);
@@ -57,8 +60,11 @@ export function useAuth() {
         error: json?.error || json?.message || defaultError,
       };
     } catch (err: any) {
+      const isTimeout = err?.name === "AbortError";
+      return { success: false, error: isTimeout ? "Network error." : (err?.message || "Network error.") };
+    } finally {
+      clearTimeout(timeoutId);
       setLoading(false);
-      return { success: false, error: err?.message || "Network error." };
     }
   }
 


### PR DESCRIPTION
## Summary
Fixes an issue where the Login and Register buttons would stay in a loading state indefinitely when the backend API server is down.

## Changes
- Added a request timeout to auth API calls (login/register)
- Ensured loading state is always cleared after a request completes or fails

## Behavior Before
- When the backend was not running, submitting Login or Register caused the button to load forever.

## Behavior After
- When the backend is unreachable, the request times out after 6 seconds and a network error is shown.
- The loading indicator stops and the user can retry.
