### PR TITLE
Fixing typos in building data (#160, #180)

### DIFF
--- a/backend/building_information.json
+++ b/backend/building_information.json
@@ -5374,42 +5374,6 @@
       "accessibility": []
     },
     {
-      "code": "TU",
-      "name": "TU Building",
-      "long_name": "TU Tunnel",
-      "address": "1550 DeMaisonneuve",
-      "latitude": 45.49648,
-      "longitude": -73.578918,
-      "metro_accessible": false,
-      "shape": {
-        "coordinates": [
-          [
-            [
-              -73.5790823,
-              45.4957182
-            ],
-            [
-              -73.5789382,
-              45.4956491
-            ],
-            [
-              -73.5789026,
-              45.4956858
-            ],
-            [
-              -73.5790457,
-              45.4957553
-            ],
-            [
-              -73.5790823,
-              45.4957182
-            ]
-          ]
-        ],
-        "type": "Polygon"
-      }
-    },
-    {
       "code": "V",
       "name": "V Building",
       "long_name": "V Annex",

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "frontend",


### PR DESCRIPTION
I removed the tunnel from the buildings json file as it is being returned as a polygon (it shouldnt be). I also just fixed the typo for FG building in that same file :)

This will close #160 and #180 

<img width="1170" height="2532" alt="uilding proof" src="https://github.com/user-attachments/assets/9db49947-728a-4df2-ac76-8f51c39b7b7e" />
