### PR TITLE
Fix 401 on endpoints using ValidateUserOwnership (#195)

### DIFF
--- a/backend/internal/presentation/middleware/user_validation.go
+++ b/backend/internal/presentation/middleware/user_validation.go
@@ -10,9 +10,9 @@ import (
 // It compares the userID from the JWT claims with the userID in the URL parameter
 func ValidateUserOwnership() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		// Get authenticated user ID from context (set by AuthMiddleware)
-		userID, exists := c.Get("userID")
-		if !exists {
+		// Get authenticated user from context (set by AuthMiddleware)
+		userClaims := GetUserFromContext(c)
+		if userClaims == nil {
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
 			c.Abort()
 			return
@@ -27,7 +27,7 @@ func ValidateUserOwnership() gin.HandlerFunc {
 		}
 
 		// Verify that the authenticated user matches the requested resource owner
-		if userID != requestedUserID {
+		if userClaims.ID != requestedUserID {
 			c.JSON(http.StatusForbidden, gin.H{"error": "Access denied: You can only access your own resources"})
 			c.Abort()
 			return

--- a/backend/internal/presentation/middleware/user_validation_test.go
+++ b/backend/internal/presentation/middleware/user_validation_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/works-on-my-machine-390/concordia-waze/internal/domain"
 	"github.com/works-on-my-machine-390/concordia-waze/internal/presentation/middleware"
 )
 
@@ -15,7 +16,7 @@ func TestValidateUserOwnershipSuccess(t *testing.T) {
 
 	// Setup middleware
 	router.Use(func(c *gin.Context) {
-		c.Set("userID", "user123")
+		c.Set("user", &domain.UserClaims{ID: "user123", Email: "test@example.com"})
 		c.Next()
 	})
 	router.Use(middleware.ValidateUserOwnership())
@@ -40,7 +41,7 @@ func TestValidateUserOwnershipForbidden(t *testing.T) {
 
 	// Setup middleware with different user
 	router.Use(func(c *gin.Context) {
-		c.Set("userID", "user123")
+		c.Set("user", &domain.UserClaims{ID: "user123", Email: "test@example.com"})
 		c.Next()
 	})
 	router.Use(middleware.ValidateUserOwnership())
@@ -87,7 +88,7 @@ func TestValidateUserOwnershipNoUserIdParam(t *testing.T) {
 
 	// Setup middleware
 	router.Use(func(c *gin.Context) {
-		c.Set("userID", "user123")
+		c.Set("user", &domain.UserClaims{ID: "user123", Email: "test@example.com"})
 		c.Next()
 	})
 	router.Use(middleware.ValidateUserOwnership())


### PR DESCRIPTION
# Description

This is a fix for #195.

The `ValidateUserOwnership` middleware, which was applied to all handlers interacting with Firebase was not correctly reading the userId from the claims.

It now reads them and authenticates the user appropriately.

## Screenshots

I make a call to the history endpoint here, and get an empty array (because my test user's history is empty). This is expected.

<img width="2560" height="1272" alt="image" src="https://github.com/user-attachments/assets/67a6dfff-6350-4512-9543-cdc82d7875b6" />

## Issues

Closes #195 