### PR TITLE
Issue #212: Adding exports for frontend test coverage report

### DIFF
--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -1,3 +1,21 @@
+module.exports = {
+  preset: "react-native",
+  testEnvironment: "node",
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
+  collectCoverage: true,
+  coverageDirectory: "coverage",
+  collectCoverageFrom: [
+    "app/**/*.{ts,tsx}",
+    "src/**/*.{ts,tsx}",
+    "!**/*.test.{ts,tsx}",
+    "!**/node_modules/**",
+    "!**/__tests__/**",
+  ],
+  testMatch: [
+    "**/__tests__/**/*.test.{ts,tsx}",
+  ],
+};
+
 // Mocking Expo Router
 jest.mock("expo-router", () => ({
   useRouter: () => ({


### PR DESCRIPTION
This will close #212 

I just add the exports to the jest setup file so that I can generate the test coverage report needed for documentation:

<img width="178" height="530" alt="image" src="https://github.com/user-attachments/assets/a6d79734-ed81-4037-8bf3-64f20f5731a9" />

inside the index.html file, you'll see the report needed