### PR TITLE
Issue #255: Ensure partial changes are saved locally for guest users in frontend

### DIFF
--- a/frontend/__tests__/guestStorage.test.ts
+++ b/frontend/__tests__/guestStorage.test.ts
@@ -11,6 +11,8 @@ import {
   addGuestSearchHistory,
   clearGuestData,
   clearGuestSearchHistory,
+  deleteGuestClass,
+  deleteGuestCourse,
   getGuestCourses,
   getGuestProfile,
   getGuestSavedAddresses,
@@ -18,6 +20,8 @@ import {
   setGuestCourses,
   setGuestProfile,
   setGuestSavedAddresses,
+  updateGuestClass,
+  updateGuestCourse,
 } from "../hooks/guestStorage";
 
 // Mock AsyncStorage
@@ -212,6 +216,253 @@ describe("guestStorage", () => {
       expect(callArgs[0]).toBe("guest:courses");
       const data = JSON.parse(callArgs[1]);
       expect(data[0].name).toBe("SOEN 384");
+    });
+
+    it("should partially update a guest course", async () => {
+      const items: CourseItem[] = [
+        {
+          name: "SOEN 384",
+          classes: [
+            {
+              type: "Lecture",
+              section: "N",
+              day: "MON",
+              startTime: "10:00",
+              endTime: "12:00",
+              buildingCode: "H",
+              room: "110",
+              origin: "manual",
+            },
+          ],
+        },
+        {
+          name: "COMP 352",
+          classes: [],
+        },
+      ];
+
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(
+        JSON.stringify(items),
+      );
+      (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+
+      await updateGuestCourse("SOEN 384", {
+        name: "SOEN 384 Updated",
+      });
+
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+        "guest:courses",
+        expect.any(String),
+      );
+
+      const savedData = JSON.parse(
+        (AsyncStorage.setItem as jest.Mock).mock.calls[0][1],
+      );
+
+      expect(savedData).toHaveLength(2);
+      expect(savedData[0].name).toBe("SOEN 384 Updated");
+      expect(savedData[0].classes[0].room).toBe("110");
+      expect(savedData[1].name).toBe("COMP 352");
+    });
+
+    it("should partially update a guest class without changing other fields", async () => {
+      const items: CourseItem[] = [
+        {
+          name: "SOEN 384",
+          classes: [
+            {
+              type: "Lecture",
+              section: "N",
+              day: "MON",
+              startTime: "10:00",
+              endTime: "12:00",
+              buildingCode: "H",
+              room: "110",
+              origin: "manual",
+            },
+            {
+              type: "Lab",
+              section: "M",
+              day: "WED",
+              startTime: "14:00",
+              endTime: "16:00",
+              buildingCode: "MB",
+              room: "2.130",
+              origin: "manual",
+            },
+          ],
+        },
+      ];
+
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(
+        JSON.stringify(items),
+      );
+      (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+
+      await updateGuestClass("SOEN 384", 0, {
+        room: "115",
+        startTime: "11:00",
+      });
+
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+        "guest:courses",
+        expect.any(String),
+      );
+
+      const savedData = JSON.parse(
+        (AsyncStorage.setItem as jest.Mock).mock.calls[0][1],
+      );
+
+      expect(savedData[0].classes[0]).toMatchObject({
+        type: "Lecture",
+        section: "N",
+        day: "MON",
+        startTime: "11:00",
+        endTime: "12:00",
+        buildingCode: "H",
+        room: "115",
+        origin: "manual",
+      });
+
+      expect(savedData[0].classes[1]).toMatchObject({
+        type: "Lab",
+        section: "M",
+        day: "WED",
+        startTime: "14:00",
+        endTime: "16:00",
+        buildingCode: "MB",
+        room: "2.130",
+        origin: "manual",
+      });
+    });
+
+    it("should delete only the selected guest class", async () => {
+      const items: CourseItem[] = [
+        {
+          name: "SOEN 384",
+          classes: [
+            {
+              type: "Lecture",
+              section: "N",
+              day: "MON",
+              startTime: "10:00",
+              endTime: "12:00",
+              buildingCode: "H",
+              room: "110",
+              origin: "manual",
+            },
+            {
+              type: "Lab",
+              section: "M",
+              day: "WED",
+              startTime: "14:00",
+              endTime: "16:00",
+              buildingCode: "MB",
+              room: "2.130",
+              origin: "manual",
+            },
+          ],
+        },
+      ];
+
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(
+        JSON.stringify(items),
+      );
+      (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+
+      await deleteGuestClass("SOEN 384", 0);
+
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+        "guest:courses",
+        expect.any(String),
+      );
+
+      const savedData = JSON.parse(
+        (AsyncStorage.setItem as jest.Mock).mock.calls[0][1],
+      );
+
+      expect(savedData).toHaveLength(1);
+      expect(savedData[0].name).toBe("SOEN 384");
+      expect(savedData[0].classes).toHaveLength(1);
+      expect(savedData[0].classes[0].type).toBe("Lab");
+    });
+
+    it("should remove the course when deleting its last guest class", async () => {
+      const items: CourseItem[] = [
+        {
+          name: "SOEN 384",
+          classes: [
+            {
+              type: "Lecture",
+              section: "N",
+              day: "MON",
+              startTime: "10:00",
+              endTime: "12:00",
+              buildingCode: "H",
+              room: "110",
+              origin: "manual",
+            },
+          ],
+        },
+        {
+          name: "COMP 352",
+          classes: [],
+        },
+      ];
+
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(
+        JSON.stringify(items),
+      );
+      (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+
+      await deleteGuestClass("SOEN 384", 0);
+
+      const savedData = JSON.parse(
+        (AsyncStorage.setItem as jest.Mock).mock.calls[0][1],
+      );
+
+      expect(savedData).toEqual([
+        {
+          name: "COMP 352",
+          classes: [],
+        },
+      ]);
+    });
+
+    it("should delete an entire guest course", async () => {
+      const items: CourseItem[] = [
+        {
+          name: "SOEN 384",
+          classes: [],
+        },
+        {
+          name: "COMP 352",
+          classes: [],
+        },
+      ];
+
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(
+        JSON.stringify(items),
+      );
+      (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+
+      await deleteGuestCourse("SOEN 384");
+
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+        "guest:courses",
+        expect.any(String),
+      );
+
+      const savedData = JSON.parse(
+        (AsyncStorage.setItem as jest.Mock).mock.calls[0][1],
+      );
+
+      expect(savedData).toEqual([
+        {
+          name: "COMP 352",
+          classes: [],
+        },
+      ]);
     });
 
     it("should clear guest data", async () => {

--- a/frontend/hooks/guestStorage.ts
+++ b/frontend/hooks/guestStorage.ts
@@ -81,6 +81,83 @@ export const setGuestCourses = async (
   await writeList(buildKey("courses"), items);
 };
 
+export const updateGuestCourse = async (
+  courseName: string,
+  updates: Partial<CourseItem>,
+): Promise<void> => {
+  const items = await getGuestCourses();
+
+  const updatedItems = items.map((course) =>
+    course.name === courseName
+      ? {
+          ...course,
+          ...updates,
+          classes: updates.classes ?? course.classes,
+        }
+      : course,
+  );
+
+  await setGuestCourses(updatedItems);
+};
+
+export const updateGuestClass = async (
+  courseName: string,
+  classIndex: number,
+  updates: Partial<CourseItem["classes"][number]>,
+): Promise<void> => {
+  const items = await getGuestCourses();
+
+  const updatedItems = items.map((course) => {
+    if (course.name !== courseName) {
+      return course;
+    }
+
+    return {
+      ...course,
+      classes: course.classes.map((classItem, index) =>
+        index === classIndex
+          ? {
+              ...classItem,
+              ...updates,
+            }
+          : classItem,
+      ),
+    };
+  });
+
+  await setGuestCourses(updatedItems);
+};
+
+export const deleteGuestClass = async (
+  courseName: string,
+  classIndex: number,
+): Promise<void> => {
+  const items = await getGuestCourses();
+
+  const updatedItems = items
+    .map((course) => {
+      if (course.name !== courseName) {
+        return course;
+      }
+
+      return {
+        ...course,
+        classes: course.classes.filter((_, index) => index !== classIndex),
+      };
+    })
+    .filter(
+      (course) => course.name !== courseName || course.classes.length > 0,
+    );
+
+  await setGuestCourses(updatedItems);
+};
+
+export const deleteGuestCourse = async (courseName: string): Promise<void> => {
+  const items = await getGuestCourses();
+  const updatedItems = items.filter((course) => course.name !== courseName);
+  await setGuestCourses(updatedItems);
+};
+
 // === Address ==
 
 export const addGuestSavedAddress = async (


### PR DESCRIPTION
### Guest Schedule Persistence
- Added guest storage helpers to support local schedule persistence for non-logged-in users
- Implemented partial update support for guest courses and guest class items
- Implemented deletion support for:
  - a single guest class item
  - an entire guest course and all its class items
- Updated guest class deletion behavior to match backend semantics:
  - deleting a class removes only that class item
  - deleting a course removes the full course

### Backend Scope Clarification
- No backend schedule/calendar endpoint changes were needed in this task
- Partial update and deletion behavior for backend schedule/calendar endpoints had already been addressed previously in closed issue **#253**
- This task focused on bringing guest/local storage behavior in line with the existing backend behavior