### PR TITLE
#272: turning expo account into organization

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -3,6 +3,7 @@
     "name": "frontend",
     "slug": "frontend",
     "version": "1.0.0",
+    "owner": "amal_sabs",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "frontend",


### PR DESCRIPTION
I am turning my expo account (the one used to build) into an organization to add @eplxy. This way, we can upgrade and get faster builds. To do this, i have to specify the owner in our `app.json`. I would commit to dev directly, but there are restrictions...